### PR TITLE
fix(action.yml): removed godot editor run command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,6 @@ runs:
         unzip Godot_v${{ inputs.godot-version }}-stable_export_templates.tpz
         mv templates/* ~/.local/share/godot/templates/${{ inputs.godot-version }}.stable
         rm -f Godot_v${{ inputs.godot-version }}-stable_linux.x86_64.zip Godot_v${{ inputs.godot-version }}-stable_export_templates.tpz
-        godot -e -q
 
     - name: Create export presets config
       if: ${{ inputs.create-export-preset-cfg  == 'true' }}


### PR DESCRIPTION
This bit was attempting to launch the editor and immediately quit. I'm trying an updated version of the `abarichello/godot-ci` container for the GTMK 2023 repo action. Just submitting this PR to show why we got X11 errors.